### PR TITLE
add par2 file verification and repair tool built from source on alpine

### DIFF
--- a/par2/Dockerfile
+++ b/par2/Dockerfile
@@ -1,0 +1,17 @@
+FROM frolvlad/alpine-gcc
+RUN apk update && \
+	apk add --no-cache --virtual .build-dependencies make g++ ca-certificates wget automake autoconf && \
+	update-ca-certificates
+RUN wget https://github.com/Parchive/par2cmdline/archive/v0.6.13.tar.gz && \
+	tar -xzvf v0.6.13.tar.gz && \
+	cd par2cmdline-0.6.13 && \
+	aclocal && \
+	automake --add-missing && \
+	autoconf && \
+	./configure && \
+	make && \
+	make install
+RUN apk del .build-dependencies && \
+	cd / && \
+	rm -rf par2cmdline-0.6.13 v0.6.13.tar.gz
+ENTRYPOINT ["par2"]


### PR DESCRIPTION
not as small as I'd hoped since I'm stuck with the gcc dependency for now