### PR TITLE
Add plantuml

### DIFF
--- a/plantuml/Dockerfile
+++ b/plantuml/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-alpine
+FROM java:8-jre-alpine
 
 ENV LANG en_US.UTF-8
 ENV PLANTUML_VERSION 8056

--- a/plantuml/Dockerfile
+++ b/plantuml/Dockerfile
@@ -1,0 +1,16 @@
+FROM java:8-alpine
+
+ENV LANG en_US.UTF-8
+ENV PLANTUML_VERSION 8056
+ENV GRAPHVIZ_DOT /usr/bin/dot
+
+RUN apk add --no-cache \
+  wget \
+  graphviz \
+  ttf-droid \
+  ttf-droid-nonlatin
+
+RUN wget "https://downloads.sourceforge.net/project/plantuml/plantuml.${PLANTUML_VERSION}.jar" \
+  -O /usr/share/plantuml.jar
+
+ENTRYPOINT ["java", "-jar", "/usr/share/plantuml.jar"]


### PR DESCRIPTION
## Why

To add http://plantuml.com/

## What

### Build

<details>
<summary>docker build</summary>

```hcl
$ docker build --no-cache -t creasty/plantuml .
Sending build context to Docker daemon 2.048 kB
Step 1/7 : FROM java:8-jre-alpine
8-jre-alpine: Pulling from library/java
b7f33cc0b48e: Already exists
43a564ae36a3: Already exists
efb75a810eee: Pull complete
Digest: sha256:48ac96e309a748f5778db26be7e45ca0e35931ef58e9b271fe36767a55411728
Status: Downloaded newer image for java:8-jre-alpine
 ---> d85b17c6762e
Step 2/7 : ENV LANG en_US.UTF-8
 ---> Running in 52b8ba47d992
 ---> 591e752c2ffe
Removing intermediate container 52b8ba47d992
Step 3/7 : ENV PLANTUML_VERSION 8056
 ---> Running in 00f7acba4b5c
 ---> e1e753052c25
Removing intermediate container 00f7acba4b5c
Step 4/7 : ENV GRAPHVIZ_DOT /usr/bin/dot
 ---> Running in 9abc2b9237dc
 ---> 8dd3bc7b4586
Removing intermediate container 9abc2b9237dc
Step 5/7 : RUN apk add --no-cache   wget   graphviz   ttf-droid   ttf-droid-nonlatin
 ---> Running in 3245ce887775
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/17) Installing expat (2.2.0-r0)
(2/17) Installing fontconfig (2.12.1-r0)
(3/17) Installing pixman (0.34.0-r0)
(4/17) Installing cairo (1.14.4-r0)
(5/17) Installing libintl (0.19.7-r3)
(6/17) Installing pcre (8.38-r1)
(7/17) Installing glib (2.48.0-r0)
(8/17) Installing libltdl (2.4.6-r0)
(9/17) Installing libxft (2.3.2-r0)
(10/17) Installing graphite2 (1.3.8-r0)
(11/17) Installing harfbuzz (1.2.7-r0)
(12/17) Installing pango (1.40.1-r0)
(13/17) Installing libstdc++ (5.3.0-r0)
(14/17) Installing graphviz (2.38.0-r5)
(15/17) Installing ttf-droid (20121017-r0)
(16/17) Installing ttf-droid-nonlatin (20121017-r0)
(17/17) Installing wget (1.18-r0)
Executing busybox-1.24.2-r12.trigger
Executing fontconfig-2.12.1-r0.trigger
Executing glib-2.48.0-r0.trigger
Executing graphviz-2.38.0-r5.trigger
OK: 190 MiB in 51 packages
 ---> 695c12d4d6c3
Removing intermediate container 3245ce887775
Step 6/7 : RUN wget "https://downloads.sourceforge.net/project/plantuml/plantuml.${PLANTUML_VERSION}.jar"   -O /usr/share/plantuml.jar
 ---> Running in bdd5338c1457
--2017-02-19 05:11:12--  https://downloads.sourceforge.net/project/plantuml/plantuml.8056.jar
Resolving downloads.sourceforge.net... 216.34.181.59
Connecting to downloads.sourceforge.net|216.34.181.59|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://jaist.dl.sourceforge.net/project/plantuml/plantuml.8056.jar [following]
--2017-02-19 05:11:13--  https://jaist.dl.sourceforge.net/project/plantuml/plantuml.8056.jar
Resolving jaist.dl.sourceforge.net... 150.65.7.130
Connecting to jaist.dl.sourceforge.net|150.65.7.130|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 5720166 (5.5M) [application/java-archive]
Saving to: '/usr/share/plantuml.jar'

     0K .......... .......... .......... .......... ..........  0% 1.13M 5s
    50K .......... .......... .......... .......... ..........  1% 2.95M 3s
   100K .......... .......... .......... .......... ..........  2%  701K 5s
   150K .......... .......... .......... .......... ..........  3% 8.83M 4s
   200K .......... .......... .......... .......... ..........  4% 5.00M 3s
   250K .......... .......... .......... .......... ..........  5% 1.09M 3s
   300K .......... .......... .......... .......... ..........  6% 2.12M 3s
   350K .......... .......... .......... .......... ..........  7% 3.14M 3s
   400K .......... .......... .......... .......... ..........  8%  857K 3s
   450K .......... .......... .......... .......... ..........  8% 19.2M 3s
   500K .......... .......... .......... .......... ..........  9% 1.41M 3s
   550K .......... .......... .......... .......... .......... 10% 2.27M 3s
   600K .......... .......... .......... .......... .......... 11% 3.07M 3s
   650K .......... .......... .......... .......... .......... 12% 4.20M 3s
   700K .......... .......... .......... .......... .......... 13%  707K 3s
   750K .......... .......... .......... .......... .......... 14% 22.7M 3s
   800K .......... .......... .......... .......... .......... 15%  122M 2s
   850K .......... .......... .......... .......... .......... 16% 1.31M 3s
   900K .......... .......... .......... .......... .......... 17% 3.01M 2s
   950K .......... .......... .......... .......... .......... 17%  808K 3s
  1000K .......... .......... .......... .......... .......... 18% 1.97M 3s
  1050K .......... .......... .......... .......... .......... 19% 12.2M 2s
  1100K .......... .......... .......... .......... .......... 20% 18.4M 2s
  1150K .......... .......... .......... .......... .......... 21% 1.74M 2s
  1200K .......... .......... .......... .......... .......... 22% 2.79M 2s
  1250K .......... .......... .......... .......... .......... 23%  651K 2s
  1300K .......... .......... .......... .......... .......... 24% 1.96M 2s
  1350K .......... .......... .......... .......... .......... 25% 25.5M 2s
  1400K .......... .......... .......... .......... .......... 25% 43.5M 2s
  1450K .......... .......... .......... .......... .......... 26% 2.35M 2s
  1500K .......... .......... .......... .......... .......... 27% 2.32M 2s
  1550K .......... .......... .......... .......... .......... 28% 2.87M 2s
  1600K .......... .......... .......... .......... .......... 29% 2.67M 2s
  1650K .......... .......... .......... .......... .......... 30% 5.05M 2s
  1700K .......... .......... .......... .......... .......... 31% 2.02M 2s
  1750K .......... .......... .......... .......... .......... 32% 3.65M 2s
  1800K .......... .......... .......... .......... .......... 33% 2.92M 2s
  1850K .......... .......... .......... .......... .......... 34% 1.79M 2s
  1900K .......... .......... .......... .......... .......... 34% 1.58M 2s
  1950K .......... .......... .......... .......... .......... 35% 3.89M 2s
  2000K .......... .......... .......... .......... .......... 36%  409K 2s
  2050K .......... .......... .......... .......... .......... 37% 20.6M 2s
  2100K .......... .......... .......... .......... .......... 38% 26.1M 2s
  2150K .......... .......... .......... .......... .......... 39% 27.3M 2s
  2200K .......... .......... .......... .......... .......... 40% 1.30M 2s
  2250K .......... .......... .......... .......... .......... 41% 3.49M 2s
  2300K .......... .......... .......... .......... .......... 42% 3.51M 2s
  2350K .......... .......... .......... .......... .......... 42% 2.06M 2s
  2400K .......... .......... .......... .......... .......... 43% 2.40M 2s
  2450K .......... .......... .......... .......... .......... 44% 1.22M 2s
  2500K .......... .......... .......... .......... .......... 45% 1.77M 2s
  2550K .......... .......... .......... .......... .......... 46% 3.13M 1s
  2600K .......... .......... .......... .......... .......... 47% 3.20M 1s
  2650K .......... .......... .......... .......... .......... 48% 1.67M 1s
  2700K .......... .......... .......... .......... .......... 49% 3.88M 1s
  2750K .......... .......... .......... .......... .......... 50% 1.40M 1s
  2800K .......... .......... .......... .......... .......... 51% 1.89M 1s
  2850K .......... .......... .......... .......... .......... 51% 1.58M 1s
  2900K .......... .......... .......... .......... .......... 52% 1.70M 1s
  2950K .......... .......... .......... .......... .......... 53% 3.91M 1s
  3000K .......... .......... .......... .......... .......... 54% 1.70M 1s
  3050K .......... .......... .......... .......... .......... 55% 2.06M 1s
  3100K .......... .......... .......... .......... .......... 56% 1.34M 1s
  3150K .......... .......... .......... .......... .......... 57%  710K 1s
  3200K .......... .......... .......... .......... .......... 58% 21.2M 1s
  3250K .......... .......... .......... .......... .......... 59% 30.7M 1s
  3300K .......... .......... .......... .......... .......... 59% 1.73M 1s
  3350K .......... .......... .......... .......... .......... 60% 1.86M 1s
  3400K .......... .......... .......... .......... .......... 61% 1.82M 1s
  3450K .......... .......... .......... .......... .......... 62% 2.22M 1s
  3500K .......... .......... .......... .......... .......... 63% 1.86M 1s
  3550K .......... .......... .......... .......... .......... 64% 1.76M 1s
  3600K .......... .......... .......... .......... .......... 65% 1.40M 1s
  3650K .......... .......... .......... .......... .......... 66% 1.36M 1s
  3700K .......... .......... .......... .......... .......... 67% 1.99M 1s
  3750K .......... .......... .......... .......... .......... 68% 2.20M 1s
  3800K .......... .......... .......... .......... .......... 68% 2.46M 1s
  3850K .......... .......... .......... .......... .......... 69%  833K 1s
  3900K .......... .......... .......... .......... .......... 70% 28.4M 1s
  3950K .......... .......... .......... .......... .......... 71% 1.80M 1s
  4000K .......... .......... .......... .......... .......... 72% 1.03M 1s
  4050K .......... .......... .......... .......... .......... 73% 1.89M 1s
  4100K .......... .......... .......... .......... .......... 74% 1.69M 1s
  4150K .......... .......... .......... .......... .......... 75% 2.02M 1s
  4200K .......... .......... .......... .......... .......... 76% 1.92M 1s
  4250K .......... .......... .......... .......... .......... 76% 1.75M 1s
  4300K .......... .......... .......... .......... .......... 77% 1.81M 1s
  4350K .......... .......... .......... .......... .......... 78% 1.81M 1s
  4400K .......... .......... .......... .......... .......... 79% 1.44M 1s
  4450K .......... .......... .......... .......... .......... 80% 2.03M 1s
  4500K .......... .......... .......... .......... .......... 81% 1.15M 1s
  4550K .......... .......... .......... .......... .......... 82% 2.02M 1s
  4600K .......... .......... .......... .......... .......... 83% 2.65M 0s
  4650K .......... .......... .......... .......... .......... 84% 2.51M 0s
  4700K .......... .......... .......... .......... .......... 85% 1.79M 0s
  4750K .......... .......... .......... .......... .......... 85% 1.53M 0s
  4800K .......... .......... .......... .......... .......... 86% 1.57M 0s
  4850K .......... .......... .......... .......... .......... 87% 1.58M 0s
  4900K .......... .......... .......... .......... .......... 88% 1.59M 0s
  4950K .......... .......... .......... .......... .......... 89% 2.45M 0s
  5000K .......... .......... .......... .......... .......... 90% 1.84M 0s
  5050K .......... .......... .......... .......... .......... 91%  757K 0s
  5100K .......... .......... .......... .......... .......... 92% 3.13M 0s
  5150K .......... .......... .......... .......... .......... 93% 2.63M 0s
  5200K .......... .......... .......... .......... .......... 93% 1.58M 0s
  5250K .......... .......... .......... .......... .......... 94% 3.49M 0s
  5300K .......... .......... .......... .......... .......... 95% 1.51M 0s
  5350K .......... .......... .......... .......... .......... 96% 1.95M 0s
  5400K .......... .......... .......... .......... .......... 97% 3.27M 0s
  5450K .......... .......... .......... .......... .......... 98% 1.82M 0s
  5500K .......... .......... .......... .......... .......... 99% 1000K 0s
  5550K .......... .......... .......... ......               100% 3.56M=2.9s

2017-02-19 05:11:16 (1.87 MB/s) - '/usr/share/plantuml.jar' saved [5720166/5720166]

 ---> ce79c5c2d572
Removing intermediate container bdd5338c1457
Step 7/7 : ENTRYPOINT java -jar /usr/share/plantuml.jar
 ---> Running in 0043115adae1
 ---> 7bc02471c176
Removing intermediate container 0043115adae1
Successfully built 7bc02471c176
```

</details>

### Test

```hcl
$ cat sample.uml
@startuml

participant Alice
participant Bob

Alice -> Bob : Hello

@enduml
```

```hcl
$ docker run -it -v "$(pwd)":/workdir -w /workdir creasty/plantuml -- -charset utf8 -tpng sample.uml
```

Result:

![sample](https://cloud.githubusercontent.com/assets/1695538/23099147/9263f14a-f6a3-11e6-8d73-a4493253ead2.png)
