### PR TITLE
allow non-root users to execute speedtest binary

### DIFF
--- a/speedtest/Dockerfile
+++ b/speedtest/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3-alpine
 ADD https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py /usr/bin/speedtest
-RUN chmod +x /usr/bin/speedtest
+RUN chmod 755 /usr/bin/speedtest
 ENTRYPOINT ["/usr/bin/speedtest"]


### PR DESCRIPTION
I found that once installed, the speedtest binary could not be executed unless running as root.

`$ sudo whalebrew install speedtest`
`🐳  Installed speedtest to /usr/local/bin/speedtest`
`$ speedtest`
`python: can't open file '/usr/bin/speedtest': [Errno 13] Permission denied`
`$ sudo speedtest`
`Retrieving speedtest.net configuration...`