### PR TITLE
Add .aws from host to awscli container

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -3,4 +3,5 @@ RUN apk add --no-cache groff less mailcap
 RUN pip install awscli
 LABEL io.whalebrew.name aws
 LABEL io.whalebrew.config.environment '["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"]'
+LABEL io.whalebrew.config.volumes '["~/.aws:/.aws"]'
 ENTRYPOINT ["aws"]


### PR DESCRIPTION
Tested and works, apparently / is used as $HOME inside of the python/alpine container