### PR TITLE
Add nmap dependencies

### DIFF
--- a/nmap/Dockerfile
+++ b/nmap/Dockerfile
@@ -1,3 +1,9 @@
 FROM alpine
-RUN apk add --no-cache nmap
+RUN apk add --no-cache \
+    nmap \
+    nmap-ncat \
+    nmap-nping \
+    nmap-nselibs \
+    nmap-scripts
+
 ENTRYPOINT ["nmap"]


### PR DESCRIPTION
Using the current nmap dockerfile, `nmap -sC <nse-script>` or `nmap --script <nse-script>` doesn't work.

This PR adds the missing dependencies for additional nmap functionality to work properly.