### PR TITLE
Jupyter-powered MXNet notebook

### DIFF
--- a/mxnet-notebook/Dockerfile
+++ b/mxnet-notebook/Dockerfile
@@ -1,0 +1,6 @@
+FROM mxnet/python
+RUN pip install jupyter matplotlib gluon
+LABEL io.whalebrew.name mxnet-notebook
+LABEL io.whalebrew.config.ports '["8888:8888"]'
+LABEL io.whalebrew.config.volumes '["~/:/root/dev:rw"]'
+ENTRYPOINT ["jupyter", "notebook", "--allow-root", "--ip='0.0.0.0'"]

--- a/mxnet-notebook/Dockerfile
+++ b/mxnet-notebook/Dockerfile
@@ -1,6 +1,11 @@
 FROM mxnet/python
-RUN pip install jupyter matplotlib gluon
+
 LABEL io.whalebrew.name mxnet-notebook
 LABEL io.whalebrew.config.ports '["8888:8888"]'
-LABEL io.whalebrew.config.volumes '["~/:/root/dev:rw"]'
+LABEL io.whalebrew.config.volumes '["$HOME:/notebook/data:rw"]'
+LABEL io.whalebrew.config.working_dir '/notebook'
+
+RUN pip install jupyter matplotlib gluon
+# Jupyter needs to create a sub directory in '.local', give the daemon permissions
+RUN mkdir /.local && chmod 777 /.local
 ENTRYPOINT ["jupyter", "notebook", "--allow-root", "--ip='0.0.0.0'"]

--- a/mxnet-notebook/README.md
+++ b/mxnet-notebook/README.md
@@ -1,0 +1,5 @@
+# Python Notebook with MXNet
+
+**built by jpbarto @ GitHub**
+
+``mxnet-notebook`` is a Jupyter-powered Python 3 notebook with [Apache MXNet](https://mxnet.incubator.apache.org/) and [Gluon](https://mxnet.incubator.apache.org/tutorials/gluon/gluon.html) installed.


### PR DESCRIPTION
This pull request creates an MXNet Notebook command (mxnet-notebook) which launches a Python 3 Jupyter notebook with Apache MXNet and Gluon installed.  Perfect for the data scientist learning the rounds.