### PR TITLE
Bump travis v1.8.9

### DIFF
--- a/travis/Dockerfile
+++ b/travis/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.4-alpine
 LABEL io.whalebrew.name travis
 LABEL io.whalebrew.config.volumes '["~/.travis:/.travis"]'
 
-ENV TRAVIS_VERSION 1.8.8
+ENV TRAVIS_VERSION 1.8.9
 
 RUN set -x && \
     apk --update add --no-cache --virtual deps build-base && \


### PR DESCRIPTION
travis CLI v1.8.9 has been released https://github.com/travis-ci/travis.rb/compare/v1.8.8...v1.8.9