### PR TITLE
New image - kubectl with gcp support (required if you want to use GKE)

### DIFF
--- a/gcloud_kubectl/Dockerfile
+++ b/gcloud_kubectl/Dockerfile
@@ -1,0 +1,10 @@
+FROM google/cloud-sdk:alpine
+RUN apk add --no-cache --update curl && \
+VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) && \
+cd /usr/local/bin && \
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$VERSION/bin/linux/amd64/kubectl && \
+chmod +x kubectl && \
+apk del curl
+LABEL io.whalebrew.name kubectl
+LABEL io.whalebrew.config.volumes '["~/.kube:/.kube", "~/.config/gcloud/:/.config/gcloud"]'
+ENTRYPOINT ["kubectl"]


### PR DESCRIPTION
In order to use kubectl against GKE, the gcloud binary, and your config, is required... Do we think this is acceptable?