### PR TITLE
Add VERSION argument for pip and github releases

### DIFF
--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:latest
+ARG VERSION
 
 RUN apk --update upgrade && \ 
     apk add \
@@ -15,7 +16,7 @@ RUN apk --update upgrade && \
 ## Adding boto and boto3 for AWS modules.  This can obviously be expanded as needed
 RUN pip install --no-cache-dir \
         pycparser==2.13 \ 
-        ansible \ 
+        ansible${VERSION+==$VERSION} \ 
         boto \ 
         boto3
 

--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:alpine
 RUN apk add --no-cache groff less mailcap
-RUN pip install awscli
+ARG VERSION
+RUN pip install awscli${VERSION+==$VERSION}
 LABEL io.whalebrew.name aws
 LABEL io.whalebrew.config.environment '["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_DEFAULT_REGION", "AWS_DEFAULT_PROFILE", "AWS_CONFIG_FILE"]'
 LABEL io.whalebrew.config.volumes '["~/.aws:/.aws"]'

--- a/awslogs/Dockerfile
+++ b/awslogs/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:alpine
-RUN pip install awslogs
+ARG VERSION
+RUN pip install awslogs${VERSION+==$VERSION}
 LABEL io.whalebrew.name awslogs
 LABEL io.whalebrew.config.environment '["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_DEFAULT_REGION", "AWS_DEFAULT_PROFILE", "AWS_CONFIG_FILE"]'
 LABEL io.whalebrew.config.volumes '["~/.aws:/.aws"]'

--- a/cfn-create-or-update/Dockerfile
+++ b/cfn-create-or-update/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:6
 LABEL io.whalebrew.name cfn-create-or-update
 
-RUN npm install -g cfn-create-or-update
+ARG VERSION
+RUN npm install -g cfn-create-or-update${VERSION+@$VERSION}
 ENTRYPOINT ["cfn-create-or-update"]

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,9 +1,10 @@
+FROM alpine AS download
+RUN apk add --no-cache --update curl bash openssl
+ARG VERSION
+RUN curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash -- /dev/stdin ${VERSION+--version ${VERSION}}
+
 FROM alpine
-RUN apk add --no-cache --update curl bash openssl && \
-cd /usr/local/bin && \
-curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash && \
-chmod +x helm && \
-apk del curl bash openssl
+COPY --from=download /usr/local/bin/helm /usr/local/bin/helm
 LABEL io.whalebrew.name helm
 LABEL io.whalebrew.config.volumes '["~/.helm:/.helm","~/.kube:/.kube"]'
 ENTRYPOINT ["helm"]

--- a/httpie/Dockerfile
+++ b/httpie/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3-alpine
-RUN pip install httpie
+ARG VERSION
+RUN pip install httpie${VERSION+==$VERSION}
 RUN mkdir /.httpie && echo "{}" > /.httpie/config.json
 ENTRYPOINT ["http"]

--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -1,8 +1,14 @@
-FROM alpine
-ENV VERSION 0.40.3
-ADD https://github.com/gohugoio/hugo/releases/download/v${VERSION}/hugo_${VERSION}_Linux-64bit.tar.gz  /tmp/hugo.tar.gz
-RUN tar -xzvf /tmp/hugo.tar.gz -C /tmp && cp /tmp/hugo /bin/hugo && chmod +x /bin/hugo && rm -r /tmp/hugo*
+FROM alpine AS download
+ARG VERSION
 
+ENV GITHUB_REPO=gohugoio/hugo
+
+RUN apk add --no-cache curl
+RUN ! [ -z "${VERSION}" ] || export VERSION=$(curl -w%{url_effective} -Ls -o /dev/null https://github.com/${GITHUB_REPO}/releases/latest | grep -oE "[^/]+$"); \
+    curl -L -s https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/hugo_${VERSION#v}_Linux-64bit.tar.gz  | gunzip | tar xv
+
+FROM alpine
+COPY --from=download /hugo /usr/local/bin/hugo
 LABEL io.whalebrew.config.ports '["1313:1313"]'
 
 ENTRYPOINT ["hugo"]

--- a/ionic/Dockerfile
+++ b/ionic/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:6
 
-RUN npm install -g cordova ionic
+ARG VERSION
+RUN npm install -g cordova ionic${VERSION+@$VERSION}
 LABEL io.whalebrew.config.ports '["8100:8100","35729:35729"]'
 
 EXPOSE 8100

--- a/kubectl/Dockerfile
+++ b/kubectl/Dockerfile
@@ -1,10 +1,13 @@
-FROM alpine
-RUN apk add --no-cache --update curl && \
-VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) && \
-cd /usr/local/bin && \
+FROM alpine AS download
+ARG VERSION
+RUN apk add --no-cache --update curl
+
+RUN ! [ -z "${VERSION}" ] || export VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt); \
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$VERSION/bin/linux/amd64/kubectl && \
-chmod +x kubectl && \
-apk del curl
+chmod +x kubectl
+
+FROM alpine
+COPY --from=download /kubectl /usr/local/bin/kubectl
 LABEL io.whalebrew.name kubectl
 LABEL io.whalebrew.config.volumes '["~/.kube:/.kube"]'
 ENTRYPOINT ["kubectl"]

--- a/lessc/Dockerfile
+++ b/lessc/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:6
 
-RUN npm install -g less
+ARG VERSION
+RUN npm install -g less${VERSION+@$VERSION}
 
 ENTRYPOINT ["lessc"]

--- a/plantuml/Dockerfile
+++ b/plantuml/Dockerfile
@@ -1,7 +1,7 @@
 FROM java:8-jre-alpine
 
 ENV LANG en_US.UTF-8
-ENV PLANTUML_VERSION 8056
+ARG VERSION=8056
 ENV GRAPHVIZ_DOT /usr/bin/dot
 
 RUN apk add --no-cache \
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
   ttf-droid \
   ttf-droid-nonlatin
 
-RUN wget "https://downloads.sourceforge.net/project/plantuml/plantuml.${PLANTUML_VERSION}.jar" \
+RUN wget "https://downloads.sourceforge.net/project/plantuml/plantuml.${VERSION}.jar" \
   -O /usr/share/plantuml.jar
 
 ENTRYPOINT ["java", "-jar", "/usr/share/plantuml.jar"]

--- a/proselint/Dockerfile
+++ b/proselint/Dockerfile
@@ -1,3 +1,4 @@
 FROM python:3-alpine
-RUN pip install proselint
+ARG VERSION
+RUN pip install proselint${VERSION+==$VERSION}
 ENTRYPOINT ["proselint"]

--- a/pygmentize/Dockerfile
+++ b/pygmentize/Dockerfile
@@ -1,3 +1,4 @@
 FROM python:3-alpine
-RUN pip install pygments
+ARG VERSION
+RUN pip install pygments${VERSION+==$VERSION}
 ENTRYPOINT ["pygmentize"]

--- a/vegeta/Dockerfile
+++ b/vegeta/Dockerfile
@@ -1,5 +1,10 @@
+FROM alpine as download
+RUN apk add --no-cache curl
+ARG VERSION
+ENV GITHUB_REPO tsenart/vegeta
+RUN ! [ -z "${VERSION}" ] || export VERSION=$(curl -w%{url_effective} -Ls -o /dev/null https://github.com/${GITHUB_REPO}/releases/latest | grep -oE "[^/]+$"); \
+    curl -L -s https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/vegeta-${VERSION#v}-linux-amd64.tar.gz | gunzip | tar xv
+
 FROM alpine
-ENV VERSION 6.1.1
-ADD https://github.com/tsenart/vegeta/releases/download/v${VERSION}/vegeta-v${VERSION}-linux-amd64.tar.gz /tmp/vegeta.tar.gz
-RUN apk update && apk --no-cache add ca-certificates && tar -zxvf /tmp/vegeta.tar.gz -C /bin && chmod +x /bin/vegeta && rm /tmp/vegeta.tar.gz && rm -rf /var/cache/*
+COPY --from=download /vegeta /usr/local/bin/vegeta
 ENTRYPOINT ["vegeta"]

--- a/youtube-dl/Dockerfile
+++ b/youtube-dl/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3-alpine
 RUN apk add --no-cache ffmpeg
-RUN pip install youtube-dl
+ARG VERSION
+RUN pip install youtube-dl${VERSION+==$VERSION}
 ENTRYPOINT ["youtube-dl"]


### PR DESCRIPTION
Add the ability to build a different version of a tool for a given
image.

This should be the first stage of being able to support multiple
versions with a given package.

Of the next things to do to explicitely support multiple packages:
- find a way to install a previous version for apk packages (see
  https://medium.com/@stschindler/the-problem-with-docker-and-alpines-package-pinning-18346593e891)
- find a way to manage transitive depencies and freeze their versions
- run the build of known versions using the --build-arg
- retrieve the list of available versions
- add tests for a given image
- eventually add the ability to select a distinct Dockerfile for a given
  version range, to allow handling interface changes