### PR TITLE
Fix travis image build

### DIFF
--- a/travis/Dockerfile
+++ b/travis/Dockerfile
@@ -8,7 +8,7 @@ ENV TRAVIS_VERSION 1.8.9
 RUN set -x && \
     apk --update add --no-cache --virtual deps build-base && \
     apk add git && \
-    gem install travis -v $TRAVIS_VERSION --no-ri --no-rdoc && \
+    gem install travis -v $TRAVIS_VERSION --no-document && \
     apk del deps
 
 ENTRYPOINT ["travis"]


### PR DESCRIPTION
options `--no-ri` and `--no-rdoc` have been removed in latest gem
versions: https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/