### PR TITLE
Fix image builds

### DIFF
--- a/openshift-cli-v2/Dockerfile
+++ b/openshift-cli-v2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.1-alpine
+FROM ruby:2.2.6-alpine
 RUN apk add --no-cache git
 RUN gem install rhc
 LABEL io.whalebrew.name rhc

--- a/plantuml/Dockerfile
+++ b/plantuml/Dockerfile
@@ -1,8 +1,5 @@
 FROM java:8-jre-alpine
 
-ENV LANG en_US.UTF-8
-ENV PLANTUML_VERSION 8056
-ENV GRAPHVIZ_DOT /usr/bin/dot
 
 RUN apk add --no-cache \
   wget \
@@ -10,7 +7,11 @@ RUN apk add --no-cache \
   ttf-droid \
   ttf-droid-nonlatin
 
-RUN wget "https://downloads.sourceforge.net/project/plantuml/plantuml.${PLANTUML_VERSION}.jar" \
+ENV LANG en_US.UTF-8
+ENV GRAPHVIZ_DOT /usr/bin/dot
+ARG PLANTUML_VERSION=1.2020.1
+
+RUN wget "https://downloads.sourceforge.net/project/plantuml/${PLANTUML_VERSION}/plantuml.${PLANTUML_VERSION}.jar" \
   -O /usr/share/plantuml.jar
 
 ENTRYPOINT ["java", "-jar", "/usr/share/plantuml.jar"]

--- a/rar/Dockerfile
+++ b/rar/Dockerfile
@@ -1,8 +1,12 @@
-FROM alpine
+FROM alpine as build
 RUN apk add --no-cache make
-RUN wget http://www.rarlab.com/rar/rarlinux-5.4.0.tar.gz && \
-	tar -xzvf rarlinux-5.4.0.tar.gz && \
-	cd rar && \
-	make && \
-	mv rar_static /usr/local/bin/rar
-ENTRYPOINT ["rar"]
+
+RUN mkdir /dl
+RUN wget -O - https://www.rarlab.com/rar/rarlinux-x64-5.8.0.tar.gz | tar -xzf - -C dl
+
+FROM debian:stable-slim
+RUN apt-get update && apt-get install libstdc++6 libc6 libgcc1
+COPY --from=build /dl/rar/rar /usr/local/bin/rar
+COPY --from=build /dl/rar/rarfiles.lst /etc/
+COPY --from=build /dl/rar/default.sfx /usr/local/lib/
+ENTRYPOINT ["/usr/local/bin/rar"]

--- a/seagull/Dockerfile
+++ b/seagull/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.04
+FROM ubuntu:18.04
 
 RUN apt-get update
 RUN apt-get -y install build-essential curl git libglib2.0-dev ksh bison flex vim tmux


### PR DESCRIPTION
Most images should be now fix

remains hyper, which build script is taken from https://github.com/hyperhq/hyper-installer/blob/master/hypercli-bootstrap.sh but which servers seems now down http://hyper.sh

A future PR will hence delete the `hyper` package