### PR TITLE
Remove hyper package

### DIFF
--- a/hyper/Dockerfile
+++ b/hyper/Dockerfile
@@ -1,8 +1,0 @@
-FROM debian
-RUN apt-get update -qq && apt-get install -qy curl && \
-    curl https://hyper-install.s3.amazonaws.com/hyper-linux-x86_64.tar.gz | tar -xvzC /usr/bin && \
-    chmod +x /usr/bin/hyper && \
-    apt-get remove --purge -y curl $(apt-mark showauto) && \
-    rm -rf /var/lib/apt/lists/*
-LABEL io.whalebrew.config.volumes '["~/.hyper:/.hyper"]'
-ENTRYPOINT ["/usr/bin/hyper"]


### PR DESCRIPTION
Hyper build fails. After investigating, the build fails as no package is
available.
The documented hyper installation script even fails:

```
curl -sSL https://hyper.sh/install | bash
curl: (6) Could not resolve host: hyper.sh
```

As the installation script from the hyper repo
https://github.com/hyperhq/hyper-installer

```
./hypercli-bootstrap.sh

Welcome to Install hyper client for HYPER_...

https://mirror-hyper-install.s3.amazonaws.com/hyper-linux-x86_64.tar.gz => /tmp/hypercli-pkg-root/hyper-linux-x86_64.tar.gz

Fetch checksum...
./hypercli-bootstrap.sh: line 130: /tmp/hypercli-pkg-root/hyper-linux-x86_64.tar.gz.md5: No such file or directory
./hypercli-bootstrap.sh: line 131: /tmp/hypercli-pkg-root/hyper-linux-x86_64.tar.gz: No such file or directory

[ERROR] : Fetch hypercli package failed, please retry!
```

The link used is though the same, but points to a bucket that now seems
deleted:

```
curl https://mirror-hyper-install.s3.amazonaws.com/hyper-linux-x86_64.tar.gz
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><BucketName>mirror-hyper-install</BucketName><RequestId>DA08DCDDFC50B2DC</RequestId><HostId>ldb0YaTGMnV5hv1Bjvcf/OkboK8n72dqrnp3BiWlcEiLeTrF3xqpz9pri8/WxfNHE3ppDWhgrJQ=</HostId></Error>
```