### PR TITLE
Add a place holder to request all image built

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,13 @@ on: # rebuild any PRs and main branch changes
     - 're-builld-all'
 
 jobs:
-  test-docker-build:
+  all-image-build-success:
+    needs:
+    - docker-build
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo success
+  docker-build:
     runs-on: ubuntu-latest
     strategy:
         fail-fast: false


### PR DESCRIPTION
github checks with github actions are per matrix variant. Using the "all-image-build-success" job allows to require all images are successfully built for pull requests