### PR TITLE
Add Neuron

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,6 +58,7 @@ jobs:
             - mitmproxy
             - mutt
             - nc
+            - neuron
             - nkf
             - nmap
             - node

--- a/neuron/Dockerfile
+++ b/neuron/Dockerfile
@@ -1,0 +1,6 @@
+FROM sridca/neuron
+LABEL io.whalebrew.config.ports '["8080:8080","1440:1440"]'
+LABEL io.whalebrew.config.volumes_from_args '["-d", "-o", "--output-dir"]'
+LABEL io.whalebrew.config.working_dir '$PWD'
+
+ENTRYPOINT ["neuron"]

--- a/neuron/README.md
+++ b/neuron/README.md
@@ -1,0 +1,27 @@
+# Neuron
+
+[Neuron](https://neuron.zettel.page) is a zettelkasten notetaking system.
+
+## Limitations of using Neuron with Whalebrew
+
+### Use as a transform tool; `neuron open` and editing functions don't work
+
+The primary usage of Neuron from Whalebrew is to serve from an existing
+Neuron notes directory. As such, `neuron open` doesn't work because
+Neuron uses `open` or `xdg-open`, and these do not exist within the container
+and cannot be passed back to the host for operation. Also,
+`neuron search --edit` won't work because the container does not ship editors.
+
+You may be able to work around this with a script that wraps the Whalebrew
+launcher.
+
+### Ports 8080 and 1440 are only serving ports
+
+Whalebrew as of 0.2.5 cannot dynamically change exposed ports, so this exposes
+ports 8080 and 1440. The latter is available in case you already have something
+running on 8080.
+
+Use `-s 0.0.0.0:8080` or `:1440`  when invoking `neuron rib` when you want to
+use Rib's built-in server from within the container.
+
+


### PR DESCRIPTION
Neuron is a zettelkasten notetaking system. Its build system relies on Nix so inclusion in Whalebrew greatly increases its accessibility to those on macOS who don't want to install Nix yet.

Fixes srid/neuron#307