### PR TITLE
Add ability to specify version for neuron

### DIFF
--- a/neuron/Dockerfile
+++ b/neuron/Dockerfile
@@ -1,4 +1,5 @@
-FROM sridca/neuron
+ARG VERSION
+FROM sridca/neuron@sha256:${VERSION}
 LABEL io.whalebrew.config.ports '["8080:8080","1440:1440"]'
 LABEL io.whalebrew.config.volumes_from_args '["-d", "-o", "--output-dir"]'
 LABEL io.whalebrew.config.working_dir '$PWD'

--- a/neuron/tags.yaml
+++ b/neuron/tags.yaml
@@ -1,0 +1,2 @@
+versions:
+- 96ce399b232eb473daf2a09794942e314bdf64816a2f09cb9dc24af4dd16fbf2


### PR DESCRIPTION
Per #92, we need an update to source files to re-trigger builds. This PR ensures that we can specify digests while published image uses `latest` tag. We'll switch to version numbers once it is stable.