### PR TITLE
fix image push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -128,8 +128,9 @@ jobs:
           for tag in $(cat "${{ matrix.image }}/tags.yaml" | docker run --rm -i whalebrew/yq  -r '.versions[]'); do
             docker tag ${{ matrix.image }}:${tag} ${{ github.event.repository.owner.name}}/${{ matrix.image }}:${tag}
             docker tag ${{ matrix.image }}:${tag} docker.pkg.github.com/${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}/${{ matrix.image }}:${tag}
+            docker push ${{ github.event.repository.owner.name}}/${{ matrix.image }}:${tag}
+            docker push docker.pkg.github.com/${{ github.event.repository.owner.name}}/${{ github.event.repository.name }}/${{ matrix.image }}:${tag}
           done
         fi
-        docker push ${{ github.event.repository.owner.name}}/${{ matrix.image }}
-        docker push docker.pkg.github.com/${{ github.event.repository.owner.name}}/${{ github.event.repository.name }}/${{ matrix.image }}
+        
       if: github.event_name == 'push' && ( steps.is-modified.outputs.modified == 'true' || github.event.ref == 'refs/heads/re-builld-all')

--- a/graphviz/Dockerfile
+++ b/graphviz/Dockerfile
@@ -5,3 +5,4 @@ RUN apk add --no-cache graphviz
 LABEL io.whalebrew.name dot 
 ENTRYPOINT [ "dot" ]
 CMD [ "--version" ]
+# force-update 2022-02-10

--- a/hugo/Dockerfile
+++ b/hugo/Dockerfile
@@ -12,3 +12,4 @@ COPY --from=download /hugo /usr/local/bin/hugo
 LABEL io.whalebrew.config.ports '["1313:1313"]'
 
 ENTRYPOINT ["hugo"]
+# force-update 2022-02-10

--- a/jq/Dockerfile
+++ b/jq/Dockerfile
@@ -5,3 +5,4 @@ RUN wget -O /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/$
 FROM scratch
 COPY --from=build /usr/local/bin/jq /usr/local/bin/jq
 ENTRYPOINT ["jq"]
+# force-update 2022-02-10

--- a/kubeseal/Dockerfile
+++ b/kubeseal/Dockerfile
@@ -16,3 +16,4 @@ FROM alpine
 COPY --from=download /download/kubeseal /bin/kubeseal
 LABEL io.whalebrew.config.volumes '["~/.kube:/.kube"]'
 ENTRYPOINT ["/bin/kubeseal"]
+# force-update 2022-02-10

--- a/neuron/Dockerfile
+++ b/neuron/Dockerfile
@@ -5,3 +5,4 @@ LABEL io.whalebrew.config.volumes_from_args '["-d", "-o", "--output-dir"]'
 LABEL io.whalebrew.config.working_dir '$PWD'
 
 ENTRYPOINT ["neuron"]
+# force-update 2022-02-10

--- a/pywhat/Dockerfile
+++ b/pywhat/Dockerfile
@@ -8,3 +8,4 @@ ARG VERSION=3.2.0
 
 RUN pip install pywhat${VERSION+==$VERSION}
 ENTRYPOINT ["pywhat"]
+# force-update 2022-02-10

--- a/vegeta/Dockerfile
+++ b/vegeta/Dockerfile
@@ -11,3 +11,4 @@ RUN ! [ -z "${VERSION}" ] || export VERSION=$(curl -w%{url_effective} -Ls -o /de
 FROM alpine
 COPY --from=download /vegeta /usr/local/bin/vegeta
 ENTRYPOINT ["vegeta"]
+# force-update 2022-02-10

--- a/youtube-dl/Dockerfile
+++ b/youtube-dl/Dockerfile
@@ -3,3 +3,4 @@ RUN apk add --no-cache ffmpeg
 ARG VERSION=2021.05.16
 RUN pip install --no-cache-dir youtube-dl${VERSION+==$VERSION}
 ENTRYPOINT ["youtube-dl"]
+# force-update 2022-02-10


### PR DESCRIPTION
In newer docker version, docker push ${image} does not push all tags of the image any longer, as expected by the script.

Also, re-trigger a build of all the tags build since the last change
<details>
<summary>
Committer details
</summary>
Local-Branch: master
</details>